### PR TITLE
fix DsName problem

### DIFF
--- a/consul/consulx.go
+++ b/consul/consulx.go
@@ -77,10 +77,10 @@ func (self *ConsulManager) InitConfig(input ...ConsulConfig) (*ConsulManager, er
 		}
 		result.Node = conf.Node
 		manager.Config = result
-		if len(result.DsName) == 0 {
+		if len(conf.DsName) == 0 {
 			consul_sessions[conf.Host] = manager
 		} else {
-			consul_sessions[result.DsName] = manager
+			consul_sessions[conf.DsName] = manager
 		}
 	}
 	if len(consul_sessions) == 0 {


### PR DESCRIPTION
we can use certain DsName with `dc.Client("default")` for the custom configuration. like:
```json
[
  {
    "DsName": "default",
    "Host":"xxxxx:8500",
    "Node": "dc/consul"
  }
]

```

Original problem is:
Line 80: result.DsName was always nil, because of result.DsName never assigned. 